### PR TITLE
no options.tablePrefix

### DIFF
--- a/lib/Lib/ParseSql.js
+++ b/lib/Lib/ParseSql.js
@@ -381,8 +381,9 @@ module.exports = {
               }
               joinStr += joinType + table;
             } else {
-              table = options.tablePrefix + table;
-              joinStr += joinType + '`' + table + '`';
+              // TODO It seems as not support tablePrefix yet.
+              var tablePrefix = options.tablePrefix || '';
+              joinStr += joinType + '`' + tablePrefix + table + '`';
             }
             if (item.as) {
               joinStr += ' AS ' + item.as;


### PR DESCRIPTION
no tablePrefix setting, will make the varibal to be a string as 'undefined' contact with table, such as 'undefinedtb_user', then throw the exception with

```
{ [Error: ER_NO_SUCH_TABLE: Table 'qiyu.undefinedqy_user' doesn't exist]
  code: 'ER_NO_SUCH_TABLE',
  errno: 1146,
  sqlState: ''42S02',
  index: 0 }
```
